### PR TITLE
Add document path as parameter for the Google Analytics call

### DIFF
--- a/src/Model/GAClient.php
+++ b/src/Model/GAClient.php
@@ -18,6 +18,7 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
      */
     public function __construct()
     {
+        /** @var Analytics analytics */
         $this->analytics = new Analytics(true);
 
         if (Mage::getIsDeveloperMode()) {
@@ -29,10 +30,10 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
     }
 
     /**
-     * @param $data
+     * @param Varien_Object $data
      * @throws Exception
      */
-    public function setTrackingData($data)
+    public function setTrackingData(Varien_Object $data)
     {
         if (!$data->getTrackingId()) {
             throw new Exception ('No tracking ID set for GA client.');
@@ -56,6 +57,10 @@ class Elgentos_ServerSideAnalytics_Model_GAClient {
 
         if ($data->getUserAgentOverride()) {
             $this->analytics->setUserAgentOverride($data->getUserAgentOverride());
+        }
+
+        if ($data->getDocumentPath()) {
+            $this->analytics->setDocumentPath($data->getDocumentPath());
         }
     }
 

--- a/src/Model/Observer.php
+++ b/src/Model/Observer.php
@@ -27,14 +27,17 @@ class Elgentos_ServerSideAnalytics_Model_Observer
             return;
         }
 
+        /** @var Elgentos_ServerSideAnalytics_Model_GAClient $client */
         $client = Mage::getModel('elgentos_serversideanalytics/gAClient');
 
         try {
             $trackingDataObject = new Varien_Object([
-                'tracking_id' => Mage::getStoreConfig(Mage_GoogleAnalytics_Helper_Data::XML_PATH_ACCOUNT),
-                'client_id' => $order->getGaUserId(),
-                'ip_override' => $order->getRemoteIp()
+                'tracking_id'   => Mage::getStoreConfig(Mage_GoogleAnalytics_Helper_Data::XML_PATH_ACCOUNT),
+                'client_id'     => $order->getGaUserId(),
+                'ip_override'   => $order->getRemoteIp(),
+                'document_path' => '/checkout/onepage/success/'
             ]);
+
             Mage::dispatchEvent('elgentos_serversideanalytics_tracking_data_transport_object', ['tracking_data_object' => $trackingDataObject]);
             $client->setTrackingData($trackingDataObject);
 


### PR DESCRIPTION
When doing the call to Google Analytics, the document path was not
sent. This made the URL in Google Analytics set to "(not set)". This
has been added now, so the actual pageview is also tracked.